### PR TITLE
Adding docker information for CNV analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ If you like, you can also use these containers as a basis for creating your own 
 The somatic copy number variation (CNV) analysis was done on WES files using a series of shell scripts generating plots of CNV as output. The series of shell scripts with the relevant reference files have been dockerized for reproducibility of the plots. The analysis can be reproduced by following the steps outlined below.
 
 1. Open a command line interface, such as Terminal.
-2. Do `docker pull jinetabanerjee/jhu_cnv_analysis:latest` to get the Docker image.
-3. Do `docker run -ti jinetabanerjee/jhu_cnv_analysis:latest bash` to start the container. 
+2. Do `docker pull nfosi/jhu_cnv_analysis:latest` to get the Docker image.
+3. Do `docker run -ti nfosi/jhu_cnv_analysis:latest bash` to start the container. 
 4. Follow the README.txt in the data_bam folder in the docker container to carry out the relevant analysis.
+5. Do `synapse -u "<username>" -p "<password>" get -r synid123` (as noted in the README.txt in the docker container to download the relevant reference files.
 
-*IMPORTANT NOTE* To save any results created during your Docker session, you'll need to mount a local directory to the Docker container when you run it. This will copy anything saved to the working directory to your local machine. Before step 3, do `mkdir data_bam` to create an input/output directory locally and store all the relevant .bam and .bam.bai files in there. Then run the command in step 3 with a `-v` flag e.g. `docker run -ti -v $PWD/data_bam:/root/data_bam/ jinetabanerjee/jhu_cnv_analysis:latest`.
+*IMPORTANT NOTE* To save any results created during your Docker session, you'll need to mount a local directory to the Docker container when you run it. This will copy anything saved to the working directory to your local machine. Before step 3, do `mkdir data_bam` to create an input/output directory locally and store all the relevant .bam and .bam.bai files in there. Then run the command in step 3 with a `-v` flag e.g. `docker run -ti -v $PWD/data_bam:/root/data_bam/ nfosi/jhu_cnv_analysis:latest`.

--- a/README.md
+++ b/README.md
@@ -89,3 +89,16 @@ If you like, you can also use these containers as a basis for creating your own 
 
 *IMPORTANT NOTE* To save any results created during your Docker session, you'll need to mount a local directory to the Docker container when you run it. This will copy anything saved to the working directory to your local machine. Before step 4, do `mkdir output` to create an output directory locally. Then run the command in step 4 with a `-v` flag e.g. `docker run -p 8888:8888 -v $PWD/output:/home/jovyan/work/output nfosi/jhu-biobank-py
 ` Alternatively, or in addition, you can save all of your results to Synapse using `synapseclient`.
+
+
+
+### CNV Analysis Docker Image (Local)
+
+The somatic copy number variation (CNV) analysis was done on WES files using a series of shell scripts generating plots of CNV as output. The series of shell scripts with the relevant reference files have been dockerized for reproducibility of the plots. The analysis can be reproduced by following the steps outlined below.
+
+1. Open a command line interface, such as Terminal.
+2. Do `docker pull jinetabanerjee/jhu_cnv_analysis:latest` to get the Docker image.
+3. Do `docker run -ti jinetabanerjee/jhu_cnv_analysis:latest bash` to start the container. 
+4. Follow the README.txt in the data_bam folder in the docker container to carry out the relevant analysis.
+
+*IMPORTANT NOTE* To save any results created during your Docker session, you'll need to mount a local directory to the Docker container when you run it. This will copy anything saved to the working directory to your local machine. Before step 3, do `mkdir data_bam` to create an input/output directory locally and store all the relevant .bam and .bam.bai files in there. Then run the command in step 3 with a `-v` flag e.g. `docker run -ti -v $PWD/data_bam:/root/data_bam/ jinetabanerjee/jhu_cnv_analysis:latest`.


### PR DESCRIPTION
I made the docker image for reproducibility of the CNV figures. So the docker image includes specific reference genome fasta files making the docker build folder too big. As a result I am adding the dockerhub link in the Readme instead of pushing the docker build folder to github. Currently the docker image exists in my personal dockerhub. Is it recommended to transfer it to nfosi?